### PR TITLE
energy_generation can by NaN

### DIFF
--- a/huawei-solar/api/pvoutput.py
+++ b/huawei-solar/api/pvoutput.py
@@ -33,7 +33,7 @@ class Status:
         parts = statusline.split(",")
         return Status(
             ts=timezone.localize(datetime.strptime(parts[0] + parts[1], "%Y%m%d%H:%M")),
-            energy_generation=int(parts[2]),
+            energy_generation=int(parts[2]) if parts[2] != "NaN" else None,
             power_generation=int(parts[3]) if parts[3] != "NaN" else None,
             energy_consumption=int(parts[4]) if parts[4] != "NaN" else None,
             power_consumption=int(parts[5]) if parts[5] != "NaN" else None,


### PR DESCRIPTION
['20200701', '09:05', 'NaN', 'NaN', '4590', '612', 'NaN', 'NaN', '241.0']
    energy_generation=int(parts[2]),
ValueError: invalid literal for int() with base 10: 'NaN'