### PR TITLE
Fixed login method for Fusionsolar

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,5 +21,7 @@ repos:
   rev: v2.3.0
   hooks:
   - id: check-yaml
+    args:
+    - --allow-multiple-documents
   - id: end-of-file-fixer
   - id: trailing-whitespace

--- a/huawei-solar/Dockerfile
+++ b/huawei-solar/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.11-slim
 
-RUN pip install --disable-pip-version-check requests pytz backoff psycopg2-binary influxdb-client==1.16.0 rsa==4.9 pkcs1==0.9.6
+RUN pip install --no-cache --disable-pip-version-check requests pytz backoff psycopg2-binary influxdb-client==1.16.0 rsa==4.9 pkcs1==0.9.7 'urllib3<2'
 
 COPY . .
 

--- a/huawei-solar/README.md
+++ b/huawei-solar/README.md
@@ -27,13 +27,13 @@ and API keys for PVOutput:
         --pvoutput-api-key xxxxxxx \
         --pvoutput-system-id 00000 \
         [--postgres-url postgres://user:pass@host/db] \
-        [--influxdb-url http://host:8086] 
+        [--influxdb-url http://host:8086]
 
 If this is the first time you run the script, add
 
     --start-date YYYY-MM-DD
 
-indicating the date when your inverter was connected to 
+indicating the date when your inverter was connected to
 the network. Next scripts runs use status based on PVOutput
 data, so this parameter is not required.
 
@@ -43,5 +43,5 @@ See [Kubernetes.md](Kubernetes.md)
 
 ## Pushing to Github Docker Registry
 
-    docker build -t  docker.pkg.github.com/szczeles/toolbelt/huawei-solar:0.2 .
-    docker push docker.pkg.github.com/szczeles/toolbelt/huawei-solar:0.2
+    docker build -t ghcr.io/szczeles/toolbelt/huawei-solar:0.22 .
+    docker push ghcr.io/szczeles/toolbelt/huawei-solar:0.22

--- a/huawei-solar/README.md
+++ b/huawei-solar/README.md
@@ -43,5 +43,5 @@ See [Kubernetes.md](Kubernetes.md)
 
 ## Pushing to Github Docker Registry
 
-    docker build -t ghcr.io/szczeles/toolbelt/huawei-solar:0.22 .
-    docker push ghcr.io/szczeles/toolbelt/huawei-solar:0.22
+    docker build -t ghcr.io/szczeles/toolbelt/huawei-solar:0.24 .
+    docker push ghcr.io/szczeles/toolbelt/huawei-solar:0.24

--- a/huawei-solar/api/fusionsolar.py
+++ b/huawei-solar/api/fusionsolar.py
@@ -148,7 +148,7 @@ class FusionSolar:
             f"https://{self.region}.fusionsolar.huawei.com/unisso/pubkey"
         ).json()
         if not pubkey["enableEncrypt"]:
-            raise NotImplementedError("Is there a region with no ecryption enabled?")
+            raise NotImplementedError("Is there a region with no encryption enabled?")
         else:
             key = rsa.PublicKey.load_pkcs1_openssl_pem(pubkey["pubKey"].encode("ascii"))
             encrypted_password = base64.b64encode(

--- a/huawei-solar/api/fusionsolar.py
+++ b/huawei-solar/api/fusionsolar.py
@@ -124,7 +124,7 @@ class FusionSolar:
 
         if response.headers["Content-Type"].startswith("text/html"):
             self.login()
-            return self.call_api(endpoint, params)
+            return self.call_api(endpoint, method, params)
 
         if response.status_code != 200:
             raise FusionSolarException(

--- a/huawei-solar/db/postgres.py
+++ b/huawei-solar/db/postgres.py
@@ -17,7 +17,7 @@ class PostgreSQL(Output):
 
         self.conn = psycopg2.connect(self.url)
         cur = self.conn.cursor()
-        fields = [f"{code} decimal(7, 3)" for code in self.signals.get_codes()]
+        fields = [f"{code} decimal(10, 3)" for code in self.signals.get_codes()]
         cur.execute(
             f"""
         CREATE TABLE IF NOT EXISTS pv (

--- a/huawei-solar/k8s.yaml
+++ b/huawei-solar/k8s.yaml
@@ -146,7 +146,7 @@ spec:
       - name: ghreg
       containers:
       - name: main
-        image: ghcr.io/szczeles/toolbelt/huawei-solar:0.22
+        image: ghcr.io/szczeles/toolbelt/huawei-solar:0.24
         envFrom:
         - secretRef:
             name: huawei-solar-secret

--- a/huawei-solar/k8s.yaml
+++ b/huawei-solar/k8s.yaml
@@ -146,8 +146,7 @@ spec:
       - name: ghreg
       containers:
       - name: main
-        #image: docker.pkg.github.com/szczeles/toolbelt/huawei-solar:0.21
-        image: huawei-solar:0.21
+        image: ghcr.io/szczeles/toolbelt/huawei-solar:0.22
         envFrom:
         - secretRef:
             name: huawei-solar-secret


### PR DESCRIPTION
It looks Fusionsolar changed the login method in January 2024 and dropped requirement of passing CSRF token to the API calls.

Fixes #38 